### PR TITLE
Little fixes and RPC support

### DIFF
--- a/src/main/kotlin/godot/codegen/Argument.kt
+++ b/src/main/kotlin/godot/codegen/Argument.kt
@@ -30,9 +30,7 @@ class Argument @JsonCreator constructor(
         if (defaultValue == "[Object:null]" || defaultValue == "Null") {
             defaultValue = "null"
             nullable = true
-        } else {
-            nullable = false
-        }
+        } else nullable = type == "Any"
 
         applyDefault = if (hasDefaultValue && nullable) {
             "null"

--- a/src/main/kotlin/godot/codegen/Enum.kt
+++ b/src/main/kotlin/godot/codegen/Enum.kt
@@ -26,8 +26,9 @@ class Enum @JsonCreator constructor(
         )
         enumBuilder.addProperty("id", Long::class)
         values.forEach { (key, value) ->
+            val newKey = if (name == "RPCMode") key.removePrefix("RPC_MODE_") else key
             enumBuilder.addEnumConstant(
-                key, TypeSpec.anonymousClassBuilder()
+                newKey, TypeSpec.anonymousClassBuilder()
                     .addSuperclassConstructorParameter("%L", value)
                     .build()
             )


### PR DESCRIPTION
This fixes two small things:
- the `RPC_MODE_` is now dropped again from the rpc enums (like it was in the kotlin native project)
- if an argument expects `Any` it is now `nullable`(`Any?`)

It also adds typesafe rpc function calls to `Node` like we have for signals.

See: https://github.com/utopia-rise/godot-jvm/pull/90