### PR TITLE
Fix windows doc gen

### DIFF
--- a/src/main/kotlin/godot/codegen/Class.kt
+++ b/src/main/kotlin/godot/codegen/Class.kt
@@ -72,7 +72,7 @@ class Class @JsonCreator constructor(
                         appendln()
                     }
                     appendln(classDoc.description)
-                }
+                }.replace(System.lineSeparator(), "\n")
             )
         }
 


### PR DESCRIPTION
This fixes doc generation for classes on windows. As kotlin poet generates with `LF` on all platforms but `buildString` uses platform specific line endings.